### PR TITLE
Fix: MetaMask chain and wallet Switching

### DIFF
--- a/CompoundComponent.md
+++ b/CompoundComponent.md
@@ -1,0 +1,80 @@
+# Compound Components
+These components are reusable and customizable compound components.
+
+### Connect Button
+This component provides the same functionality as the one from *Pure Components*. The difference here is in the way of implementation. 
+
+### Usage
+```tsx
+"use client";
+import { ConnectButtonPrimitive } from "@nazeeh2000/comp-kit";
+
+export default function Home() {
+  return (
+    <>
+      <ConnectButtonPrimitive>
+        <ConnectButtonPrimitive.Button>
+          Compound Connect Button
+        </ConnectButtonPrimitive.Button>
+        <ConnectButtonPrimitive.Modal
+          closeOnOverlayClick={true}
+          style={{ /* YOUR CUSTOM STYLES */ }}
+          closeButtonProps={{ style: { /* YOUR CUSTOM STYLES FOR CLOSE BUTTON */ } }}
+        >
+          <ConnectButtonPrimitive.MetaMaskButton
+            style={{ background: "yellow" }}
+          >
+            Metamask
+          </ConnectButtonPrimitive.MetaMaskButton>
+          <ConnectButtonPrimitive.WalletConnect
+            style={{ background: "yellow" }}
+          >
+            WalletConnect
+          </ConnectButtonPrimitive.WalletConnect>
+        </ConnectButtonPrimitive.Modal>
+        <ConnectButtonPrimitive.DisconnectButton>
+          Disconnect Wallet
+        </ConnectButtonPrimitive.DisconnectButton>
+      </ConnectButtonPrimitive>
+    </>
+  );
+}
+```
+### Switch Network
+This component also provides the same functionality as the one from *Pure Components*. The only difference here is in the way of implementation.
+
+### Usage
+```tsx
+"use client";
+import { SwitchNetworkWrapper } from "@nazeeh2000/comp-kit";
+import { arbitrum, goerli, mainnet, polygonMumbai } from "viem/chains";
+
+export default function Home() {
+  return (
+    <>
+      <SwitchNetworkWrapper style={{ background: "cyan" }}>
+        <SwitchNetworkWrapper.Option
+          style={{ border: "2px solid cyan", background: "red" }}
+          value={mainnet}
+        >
+          mainnet 1
+        </SwitchNetworkWrapper.Option>
+        <SwitchNetworkWrapper.Option value={goerli}>
+          goerli 2
+        </SwitchNetworkWrapper.Option>
+        <SwitchNetworkWrapper.Option css={{ color: "blue" }} value={arbitrum}>
+          arbitrum 3
+        </SwitchNetworkWrapper.Option>
+        <SwitchNetworkWrapper.Option
+          css={{ color: "blue" }}
+          value={polygonMumbai}
+        >
+          polygonMumbai
+        </SwitchNetworkWrapper.Option>
+      </SwitchNetworkWrapper>
+    </>
+  );
+}
+```
+
+> Note: Make sure your app is wrapped with the necessary provider [`KitProvider`](./README.md#kitprovider).

--- a/PureComponent.md
+++ b/PureComponent.md
@@ -1,0 +1,41 @@
+# Pure Components
+Pure components are reusable, ready-to-use, and non-customizable components.
+
+### Connect Button
+This is the main button to connect your dapp with your wallet. This component is responsible for rendering **Connect button** when not connected and rendering the **connected address** and **Disconnect** Button if connected.
+
+```tsx
+"use client";
+import { ConnectButton } from "@nazeeh2000/comp-kit";
+
+export default function Home() {
+  return (
+    <>
+      <ConnectButton />
+    </>
+  );
+}
+```
+> Note: Make sure your app is wrapped with the necessary provider [`KitProvider`](./README.md#kitprovider).
+
+### Switch Network 
+This component will provide you with the Network selection dropdown with pre-filled values of chains provided in the `supportedChains` props of the `KitProvider`.
+
+If the user is on a network that is not included in the `supportedChains` array, then it will show **Wrong Network** and will prompt the user to switch to any of the supported chains.
+
+This dropdown will also display the current network status by displaying a green dot next to the current network, and if network switching is in progress or the user has yet to confirm from the wallet, it will display a yellow indicator next to the chain on which the user wishes to switch.
+
+```tsx
+"use client";
+import { SwitchNetworks } from "@nazeeh2000/comp-kit";
+
+export default function Home() {
+  return (
+    <>
+      <SwitchNetworks />
+    </>
+  );
+}
+```
+
+> Note: You can pass `variant` prop to both of these components whose value will be `light` or `dark` depending on the theme of your dapp.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,87 @@
 # Comp-kit
 
-A UI component library for web3 built on top of [viem](https://viem.sh/)
+Comp-kit is a React component library for web3 built on top of [viem](https://viem.sh/). It provides ready-to-use as well as reusable components built using [stitches](https://stitches.dev/). Apart from that, it offers a collection of React hooks that provide you with everything you need to get started with Ethereum. 
 
-Refer to the docs [here](https://nazeehs-org.gitbook.io/comp-kit/)
+> Note: You can refer to the docs here Refer to the docs [here](https://nazeehs-org.gitbook.io/comp-kit/)
 
-List of compoents:
-- Connect Wallet
-- Switch Network
+## Installation
+Install `comp-kit` and its peer dependencies. I am using `yarn` as the package manager, you can use the package manager of your choice.
+
+```bash
+yarn add @nazeeh2000/comp-kit viem @stitches/react @walletconnect/modal @walletconnect/ethereum-provider 
+```
+
+## Configuration
+
+Once you're done with the installation of the dependencies, you need to wrap your app with the `KitProviser` wrapper imported from the `@nazeeh2000/comp-kit` package.
+```tsx
+'use client'
+import { KitProvider } from "@nazeeh2000/comp-kit";
+import "./globals.css";
+import { Inter } from "next/font/google";
+import { arbitrum, mainnet, polygon } from "viem/chains";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <KitProvider
+          projectId="" // WallectConnect projectId
+          supportedChains={[mainnet, polygon, arbitrum]}
+        >
+          {children}
+        </KitProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+## Usage
+### Public Client
+In order to use `publicClient`, import `usePublicClient` from "@nazeeh2000/comp-kit". The return value of this hook will be a `Record` containing the `publicClient` corresponding to the network name.
+
+You can use `publicClient` in your component as per the below example.
+
+```tsx
+'use client'
+import { usePublicClient } from "@nazeeh2000/comp-kit";
+import { mainnet } from "viem/chains";
+
+export default function Home() {
+    const publicClient = usePublicClient();
+    // publicClient for mainnet
+    const mainnetPublicClient = publicClient[mainnet.name]
+
+    return (
+    // Your component
+    )
+}
+```
+### WalletClient
+In order to use `walletClient`, import `useWalletClient` from "@nazeeh2000/comp-kit". The return value of this hook will be `walletClient` that you can use in any part of your dapp.
+
+You can use `walletClient` in your component as per the below example.
+```tsx
+'use client'
+import { useWalletClient } from "@nazeeh2000/comp-kit";
+
+export default function Home() {
+    const walletClient = useWalletClient();
+
+    return (
+    // Your component
+    )
+}
+```
+### Pure Component
+In order to use Pure and Ready to use components, refer to the guide [here](./PureComponent.md)
+
+### Compound Component
+In order to use Compound and Ready to use components, refer to the guide [here](./CompoundComponent.md)

--- a/README.md
+++ b/README.md
@@ -85,3 +85,8 @@ In order to use Pure and Ready to use components, refer to the guide [here](./Pu
 
 ### Compound Component
 In order to use Compound and Ready to use components, refer to the guide [here](./CompoundComponent.md)
+
+### Hooks
+There are mainly 2 hooks provided by the `comp-kit` to access data regarding the account and network. 
+- [`useAccount`](./useAccount.md)
+- [`useChain`](./useChain.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nazeeh2000/comp-kit",
-  "version": "0.0.15-development",
+  "version": "0.0.16-development",
   "description": "This is a UI library consisting of components for web3 and web2 users",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package/src/components/ConnectButton/ConnectButton.tsx
+++ b/package/src/components/ConnectButton/ConnectButton.tsx
@@ -5,8 +5,8 @@ import {
   useWalletConnecting,
   useWalletStatus,
 } from '../KitProvider/AddressContext';
-import { useMetaMaskWallet } from '../Wallets/metaMaskWallet';
-import { useWalletConnectWallet } from '../Wallets/walletConnectWallet';
+import { useMetaMaskWallet } from '../Wallets/MetaMask/metaMaskWallet';
+import { useWalletConnectWallet } from '../Wallets/WalletConnect/walletConnectWallet';
 import { Button } from '../ui/Button/Button';
 import { Modal } from '../ui/Modal/Modal';
 import {

--- a/package/src/components/KitProvider/AddressContext.tsx
+++ b/package/src/components/KitProvider/AddressContext.tsx
@@ -89,7 +89,7 @@ export const AddressContextProvider: FC<AddressContextProviderProps> = ({
   useEffect(() => {
     // add listeners to listen account changes in metamask
     if (
-      getPrevWallet() === 'MetaMask' &&
+      walletProvider === 'MetaMask' &&
       typeof window !== 'undefined' &&
       window?.ethereum
     ) {
@@ -108,21 +108,23 @@ export const AddressContextProvider: FC<AddressContextProviderProps> = ({
         console.log('accountsChanges', accounts);
       });
     };
-  }, []);
+  }, [walletProvider]);
 
   useEffect(() => {
     // persists address on reload if wallet is metamask
-    void (async () => {
-      const accounts = await walletClient?.getAddresses();
+    if (getPrevWallet() === 'MetaMask' && walletProvider === 'MetaMask') {
+      void (async () => {
+        const accounts = await walletClient?.getAddresses();
 
-      if (accounts && accounts.length > 0) {
-        setAddress(accounts);
-        console.log('Setting address', accounts);
-      } else {
-        setAddress(undefined);
-      }
-    })();
-  }, [walletClient]);
+        if (accounts && accounts.length > 0) {
+          setAddress(accounts);
+          console.log('Setting address', accounts);
+        } else {
+          setAddress(undefined);
+        }
+      })();
+    }
+  }, [walletClient, walletProvider]);
 
   useEffect(() => {
     if (getPrevWallet() === 'WalletConnect') {
@@ -130,6 +132,7 @@ export const AddressContextProvider: FC<AddressContextProviderProps> = ({
       if (data) {
         console.log('data: ', data);
         setAddress(data.data.accounts);
+        setWalletProvider('WalletConnect');
       }
     } else if (
       // persists walletClient on reload if wallet is metamask
@@ -142,6 +145,7 @@ export const AddressContextProvider: FC<AddressContextProviderProps> = ({
         transport: custom((window.ethereum as unknown) as EthereumProvider),
       });
       setWalletClient(walletClient);
+      setWalletProvider('MetaMask');
     }
   }, []);
 

--- a/package/src/components/KitProvider/AddressContext.tsx
+++ b/package/src/components/KitProvider/AddressContext.tsx
@@ -1,4 +1,3 @@
-import EthereumProvider from '@walletconnect/ethereum-provider/dist/types/EthereumProvider';
 import React, {
   FC,
   ReactNode,
@@ -9,14 +8,9 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { Address, createWalletClient, custom } from 'viem';
-import { mainnet } from 'viem/chains';
-import {
-  getPrevAccount,
-  getPrevWallet,
-  removePrevAccount,
-  removePrevWallet,
-} from '../../utils/utils';
+import { Address } from 'viem';
+import { removePrevAccount, removePrevWallet } from '../../utils/utils';
+import { MetaMaskFunc } from '../Wallets/MetaMask/MetamaskFunc';
 import { useSetWalletClient, useWalletClient } from './KitProvider';
 
 interface AddressContextProps {
@@ -87,69 +81,6 @@ export const AddressContextProvider: FC<AddressContextProviderProps> = ({
   }, [walletClient]);
 
   useEffect(() => {
-    // add listeners to listen account changes in metamask
-    if (
-      walletProvider === 'MetaMask' &&
-      typeof window !== 'undefined' &&
-      window?.ethereum
-    ) {
-      window.ethereum.on('accountsChanged', accounts => {
-        console.log('accountsChanges', accounts);
-        if (accounts && accounts.length > 0) {
-          console.log('Setting address', accounts);
-          setAddress((accounts as unknown) as Address[]);
-        }
-      });
-    }
-    return () => {
-      // @ts-expect-error trying to remove eventLister on window.ethereum object
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      window?.ethereum?.removeListener('accountsChanged', accounts => {
-        console.log('accountsChanges', accounts);
-      });
-    };
-  }, [walletProvider]);
-
-  useEffect(() => {
-    // persists address on reload if wallet is metamask
-    if (getPrevWallet() === 'MetaMask' && walletProvider === 'MetaMask') {
-      void (async () => {
-        const accounts = await walletClient?.getAddresses();
-
-        if (accounts && accounts.length > 0) {
-          setAddress(accounts);
-          console.log('Setting address', accounts);
-        } else {
-          setAddress(undefined);
-        }
-      })();
-    }
-  }, [walletClient, walletProvider]);
-
-  useEffect(() => {
-    if (getPrevWallet() === 'WalletConnect') {
-      const data = getPrevAccount();
-      if (data) {
-        console.log('data: ', data);
-        setAddress(data.data.accounts);
-        setWalletProvider('WalletConnect');
-      }
-    } else if (
-      // persists walletClient on reload if wallet is metamask
-      getPrevWallet() === 'MetaMask' &&
-      typeof window !== 'undefined' &&
-      window?.ethereum
-    ) {
-      const walletClient = createWalletClient({
-        chain: mainnet,
-        transport: custom((window.ethereum as unknown) as EthereumProvider),
-      });
-      setWalletClient(walletClient);
-      setWalletProvider('MetaMask');
-    }
-  }, []);
-
-  useEffect(() => {
     console.log('address from AddressContext: ', address);
   }, [address]);
   useEffect(() => {
@@ -196,7 +127,7 @@ export const AddressContextProvider: FC<AddressContextProviderProps> = ({
         ]
       )}
     >
-      {children}
+      <MetaMaskFunc>{children}</MetaMaskFunc>
     </AddressContext.Provider>
   );
 };

--- a/package/src/components/KitProvider/ChainContext.tsx
+++ b/package/src/components/KitProvider/ChainContext.tsx
@@ -6,14 +6,15 @@ import React, {
   useState,
 } from 'react';
 import { Chain } from 'viem';
-import { usePublicClient, useWalletClient } from './KitProvider';
-import { getChain } from '../../utils/utils';
 import { useSwitchChain } from '../../hooks/useSwitchChain';
+import { getChain } from '../../utils/utils';
+import { useWalletClient } from './KitProvider';
 
 export interface ChainContextProps {
   supportedChains: Chain[];
   initialChain?: Chain;
   currentChain?: Chain;
+  setCurrentChain?: React.Dispatch<React.SetStateAction<Chain | undefined>>;
   switchingToChainId?: number | null;
 }
 
@@ -21,6 +22,7 @@ const ChainContext = createContext<ChainContextProps>({
   supportedChains: [],
   initialChain: undefined,
   currentChain: undefined,
+  setCurrentChain: undefined,
   switchingToChainId: undefined,
 });
 
@@ -35,7 +37,6 @@ export const ChainContextProvider = ({
 }: ChainContextProviderProps) => {
   const walletClient = useWalletClient();
   const [currentChain, setCurrentChain] = useState<Chain | undefined>();
-  const publicClient = usePublicClient();
 
   const { switchChain, switchingToChainId } = useSwitchChain();
 
@@ -62,9 +63,7 @@ export const ChainContextProvider = ({
       });
     } else {
       const fetchChain = async () => {
-        const block = await publicClient?.[
-          supportedChains[0].name
-        ]?.getChainId();
+        const block = await walletClient?.getChainId();
         setCurrentChain(getChain(block || 1));
         return;
       };
@@ -78,7 +77,7 @@ export const ChainContextProvider = ({
         setCurrentChain(getChain(+chainId));
       });
     };
-  }, [publicClient, supportedChains]);
+  }, [walletClient]);
 
   useEffect(() => {
     console.log('initialChain from chainContext: ', initialChain);
@@ -96,9 +95,16 @@ export const ChainContextProvider = ({
           supportedChains,
           initialChain,
           currentChain,
+          setCurrentChain,
           switchingToChainId,
         }),
-        [supportedChains, initialChain, currentChain, switchingToChainId]
+        [
+          supportedChains,
+          initialChain,
+          currentChain,
+          switchingToChainId,
+          setCurrentChain,
+        ]
       )}
     >
       {children}
@@ -112,6 +118,9 @@ export const useSupportedChains = () =>
 export const useInitialChain = () => useContext(ChainContext).initialChain;
 
 export const useCurrentChain = () => useContext(ChainContext).currentChain;
+
+export const useSetCurrentChain = () =>
+  useContext(ChainContext).setCurrentChain;
 
 export const useChain = () => {
   const { currentChain, supportedChains } = useContext(ChainContext);

--- a/package/src/components/KitProvider/ChainContext.tsx
+++ b/package/src/components/KitProvider/ChainContext.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import { Chain } from 'viem';
 import { useSwitchChain } from '../../hooks/useSwitchChain';
-import { getChain } from '../../utils/utils';
 import { useWalletClient } from './KitProvider';
 
 export interface ChainContextProps {
@@ -39,45 +38,6 @@ export const ChainContextProvider = ({
   const [currentChain, setCurrentChain] = useState<Chain | undefined>();
 
   const { switchChain, switchingToChainId } = useSwitchChain();
-
-  useEffect(() => {
-    // detect on which chain user is whenever user reloads
-    void (async () => {
-      if (typeof window !== 'undefined' && window.ethereum) {
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        const chainId = await window.ethereum.request({
-          method: 'eth_chainId',
-        });
-        console.log('chainId from users metamask: ', chainId);
-        chainId && setCurrentChain(getChain(+chainId));
-      }
-    })();
-  }, []);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && window?.ethereum) {
-      // detect Metamask chain change
-      window.ethereum.on('chainChanged', (chainId: string) => {
-        console.log('detected chainChanged', chainId);
-        setCurrentChain(getChain(+chainId));
-      });
-    } else {
-      const fetchChain = async () => {
-        const block = await walletClient?.getChainId();
-        setCurrentChain(getChain(block || 1));
-        return;
-      };
-      void fetchChain();
-    }
-    return () => {
-      // @ts-expect-error trying to remove eventLister on window.ethereum object
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      window?.ethereum?.removeListener('chainChanged', chainId => {
-        console.log('detected chainChanged', chainId);
-        setCurrentChain(getChain(+chainId));
-      });
-    };
-  }, [walletClient]);
 
   useEffect(() => {
     console.log('initialChain from chainContext: ', initialChain);

--- a/package/src/components/SwitchNetwork/SwitchNetwork.tsx
+++ b/package/src/components/SwitchNetwork/SwitchNetwork.tsx
@@ -3,19 +3,27 @@ import { Chain } from 'viem/chains';
 import { useSwitchChain } from '../../hooks/useSwitchChain';
 import {
   useCurrentChain,
+  useSetCurrentChain,
   useSupportedChains,
 } from '../KitProvider/ChainContext';
 import { Select } from '../ui/Select/Select';
-import { useIsConnected } from '../KitProvider/AddressContext';
+import {
+  useIsConnected,
+  useWalletProvider,
+} from '../KitProvider/AddressContext';
+import { getChain } from '../../utils/utils';
 
 export const SwitchNetworks = () => {
   const supportedChains = useSupportedChains();
   const { switchChain, switchingToChainId } = useSwitchChain();
   const currentChain = useCurrentChain();
+  const setCurrentChain = useSetCurrentChain();
   const isConnected = useIsConnected();
   const [value, setValue] = React.useState<Chain>(
     currentChain ?? supportedChains[0]
   );
+
+  const walletProvider = useWalletProvider();
 
   useEffect(() => {
     console.log('currentChain from switchNetwork: ', currentChain);
@@ -31,6 +39,8 @@ export const SwitchNetworks = () => {
     const newChainId = await switchChain(+value.id);
     console.log({ newChainId });
     !!newChainId && typeof newChainId === 'number' && setValue(value);
+    walletProvider === 'WalletConnect' &&
+      setCurrentChain?.(getChain(+newChainId));
   };
 
   return (

--- a/package/src/components/Wallets/MetaMask/MetamaskFunc.tsx
+++ b/package/src/components/Wallets/MetaMask/MetamaskFunc.tsx
@@ -1,0 +1,141 @@
+import React, { ReactNode, useEffect } from 'react';
+import { useSetCurrentChain } from '../../KitProvider/ChainContext';
+import { getChain, getPrevAccount, getPrevWallet } from '../../../utils/utils';
+import {
+  useSetWalletClient,
+  useWalletClient,
+} from '../../KitProvider/KitProvider';
+import {
+  useSetAddress,
+  useSetWalletProvider,
+  useWalletProvider,
+} from '../../KitProvider/AddressContext';
+import { Address, createWalletClient, custom } from 'viem';
+import EthereumProvider from '@walletconnect/ethereum-provider/dist/types/EthereumProvider';
+import { mainnet } from 'viem/chains';
+
+interface MetaMaskFuncProps {
+  children: ReactNode;
+}
+
+export const MetaMaskFunc: React.FC<MetaMaskFuncProps> = ({ children }) => {
+  const setCurrentChain = useSetCurrentChain();
+  const walletClient = useWalletClient();
+  const walletProvider = useWalletProvider();
+  const setAddress = useSetAddress();
+  const setWalletProvider = useSetWalletProvider();
+  const setWalletClient = useSetWalletClient();
+
+  useEffect(() => {
+    // add listeners to listen account changes in metamask
+    if (
+      walletProvider === 'MetaMask' &&
+      typeof window !== 'undefined' &&
+      window?.ethereum
+    ) {
+      window.ethereum.on('accountsChanged', accounts => {
+        console.log('accountsChanges', accounts);
+        if (accounts && accounts.length > 0) {
+          console.log('Setting address', accounts);
+          setAddress((accounts as unknown) as Address[]);
+        }
+      });
+    }
+    return () => {
+      // @ts-expect-error trying to remove eventLister on window.ethereum object
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      window?.ethereum?.removeListener('accountsChanged', accounts => {
+        console.log('accountsChanges', accounts);
+      });
+    };
+  }, [walletProvider]);
+
+  useEffect(() => {
+    // persists address on reload if wallet is metamask
+    if (getPrevWallet() === 'MetaMask' && walletProvider === 'MetaMask') {
+      void (async () => {
+        const accounts = await walletClient?.getAddresses();
+
+        if (accounts && accounts.length > 0) {
+          setAddress(accounts);
+          console.log('Setting address', accounts);
+        } else {
+          setAddress(undefined);
+        }
+      })();
+    }
+  }, [walletClient, walletProvider]);
+
+  useEffect(() => {
+    if (getPrevWallet() === 'WalletConnect') {
+      const data = getPrevAccount();
+      if (data) {
+        console.log('data: ', data);
+        setAddress(data.data.accounts);
+        setWalletProvider('WalletConnect');
+      }
+    } else if (
+      // persists walletClient on reload if wallet is metamask
+      getPrevWallet() === 'MetaMask' &&
+      typeof window !== 'undefined' &&
+      window?.ethereum
+    ) {
+      const walletClient = createWalletClient({
+        chain: mainnet,
+        transport: custom((window.ethereum as unknown) as EthereumProvider),
+      });
+      setWalletClient(walletClient);
+      setWalletProvider('MetaMask');
+    }
+  }, []);
+
+  useEffect(() => {
+    // detect on which chain user is whenever user reloads
+    void (async () => {
+      if (
+        getPrevWallet() === 'MetaMask' &&
+        walletProvider === 'MetaMask' &&
+        typeof window !== 'undefined' &&
+        window.ethereum
+      ) {
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        const chainId = await window.ethereum.request({
+          method: 'eth_chainId',
+        });
+        console.log('chainId from users metamask: ', chainId);
+        chainId && setCurrentChain?.(getChain(+chainId));
+      }
+    })();
+  }, [walletProvider]);
+
+  useEffect(() => {
+    if (
+      walletProvider === 'MetaMask' &&
+      typeof window !== 'undefined' &&
+      window?.ethereum
+    ) {
+      // detect Metamask chain change
+      window.ethereum.on('chainChanged', (chainId: string) => {
+        console.log('detected chainChanged', chainId);
+        setCurrentChain?.(getChain(+chainId));
+      });
+    } else {
+      const fetchChain = async () => {
+        const block = await walletClient?.getChainId();
+        setCurrentChain?.(getChain(block || 1));
+        return;
+      };
+      void fetchChain();
+    }
+    return () => {
+      // @ts-expect-error trying to remove eventLister on window.ethereum object
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      window?.ethereum?.removeListener('chainChanged', chainId => {
+        console.log('detected chainChanged', chainId);
+        setCurrentChain?.(getChain(+chainId));
+      });
+    };
+  }, [walletClient]);
+
+  return <>{children}</>;
+};

--- a/package/src/components/Wallets/MetaMask/MetamaskFunc.tsx
+++ b/package/src/components/Wallets/MetaMask/MetamaskFunc.tsx
@@ -52,7 +52,7 @@ export const MetaMaskFunc: React.FC<MetaMaskFuncProps> = ({ children }) => {
 
   useEffect(() => {
     // persists address on reload if wallet is metamask
-    if (getPrevWallet() === 'MetaMask' && walletProvider === 'MetaMask') {
+    if (walletProvider === 'MetaMask') {
       void (async () => {
         const accounts = await walletClient?.getAddresses();
 
@@ -93,7 +93,6 @@ export const MetaMaskFunc: React.FC<MetaMaskFuncProps> = ({ children }) => {
     // detect on which chain user is whenever user reloads
     void (async () => {
       if (
-        getPrevWallet() === 'MetaMask' &&
         walletProvider === 'MetaMask' &&
         typeof window !== 'undefined' &&
         window.ethereum

--- a/package/src/components/Wallets/MetaMask/metaMaskWallet.tsx
+++ b/package/src/components/Wallets/MetaMask/metaMaskWallet.tsx
@@ -2,15 +2,15 @@ import { EthereumProvider } from '@walletconnect/ethereum-provider';
 import { createWalletClient, custom } from 'viem';
 import { mainnet } from 'viem/chains';
 import { BaseRpcRequests } from 'viem/dist/types/clients/transports/createTransport';
-import { useSetWalletClient } from '../KitProvider/KitProvider';
+import { useSetWalletClient } from '../../KitProvider/KitProvider';
 import {
   useSetAddress,
   useSetConnectWalletError,
   useSetWalletConnecting,
   useSetWalletProvider,
-} from '../KitProvider/AddressContext';
-import { useCurrentChain } from '../KitProvider/ChainContext';
-import { storePrevAccount, storePrevWallet } from '../../utils/utils';
+} from '../../KitProvider/AddressContext';
+import { useCurrentChain } from '../../KitProvider/ChainContext';
+import { storePrevAccount, storePrevWallet } from '../../../utils/utils';
 
 type EthereumProvider = { request: BaseRpcRequests['request'] };
 

--- a/package/src/components/Wallets/WalletConnect/walletConnectWallet.tsx
+++ b/package/src/components/Wallets/WalletConnect/walletConnectWallet.tsx
@@ -7,20 +7,20 @@ import {
   useSetConnectWalletError,
   useSetWalletConnecting,
   useSetWalletProvider,
-} from '../KitProvider/AddressContext';
-import { useProjectId, useSetWalletClient } from '../KitProvider/KitProvider';
+} from '../../KitProvider/AddressContext';
+import { useProjectId, useSetWalletClient } from '../../KitProvider/KitProvider';
 import {
   useCurrentChain,
   useSetCurrentChain,
   useSupportedChains,
-} from '../KitProvider/ChainContext';
+} from '../../KitProvider/ChainContext';
 import {
   getChain,
   getPrevAccount,
   getPrevWallet,
   storePrevAccount,
   storePrevWallet,
-} from '../../utils/utils';
+} from '../../../utils/utils';
 import { useEffect } from 'react';
 
 interface useWalletConnectWalletProps {

--- a/package/src/components/Wallets/WalletConnect/walletConnectWallet.tsx
+++ b/package/src/components/Wallets/WalletConnect/walletConnectWallet.tsx
@@ -67,8 +67,9 @@ export const useWalletConnectWallet = ({
           });
 
           setCurrentChain?.(getChain(storedChainData.id));
-
+          await provider.connect();
           provider.on('chainChanged', (chainId: string) => {
+            console.log('chainChanged after reconnect', chainId);
             setCurrentChain?.(getChain(+chainId));
           });
 
@@ -79,7 +80,6 @@ export const useWalletConnectWallet = ({
 
           setWalletProvider('WalletConnect');
           setWalletClient(walletClient);
-          setAddress(accounts);
         }
       } catch (error) {
         console.log(
@@ -97,7 +97,7 @@ export const useWalletConnectWallet = ({
       }
     };
 
-    void reconnect();
+    getPrevWallet() === 'WalletConnect' && void reconnect();
   }, []);
 
   return {
@@ -114,6 +114,10 @@ export const useWalletConnectWallet = ({
 
         provider.on('display_uri', (uri: string) => {
           console.log('URI: ', uri);
+        });
+
+        provider.on('chainChanged', (chainId: string) => {
+          setCurrentChain?.(getChain(+chainId));
         });
 
         await provider.connect();

--- a/package/src/components/Wallets/WalletConnect/walletConnectWallet.tsx
+++ b/package/src/components/Wallets/WalletConnect/walletConnectWallet.tsx
@@ -8,7 +8,10 @@ import {
   useSetWalletConnecting,
   useSetWalletProvider,
 } from '../../KitProvider/AddressContext';
-import { useProjectId, useSetWalletClient } from '../../KitProvider/KitProvider';
+import {
+  useProjectId,
+  useSetWalletClient,
+} from '../../KitProvider/KitProvider';
 import {
   useCurrentChain,
   useSetCurrentChain,

--- a/package/src/components/Wallets/walletConnectWallet.tsx
+++ b/package/src/components/Wallets/walletConnectWallet.tsx
@@ -17,6 +17,7 @@ import {
 import {
   getChain,
   getPrevAccount,
+  getPrevWallet,
   storePrevAccount,
   storePrevWallet,
 } from '../../utils/utils';
@@ -51,7 +52,11 @@ export const useWalletConnectWallet = ({
 
     const reconnect = async () => {
       try {
-        if (accounts && storedChainData) {
+        if (
+          getPrevWallet() === 'WalletConnect' &&
+          accounts &&
+          storedChainData
+        ) {
           const provider = await EthereumProvider.init({
             chains: [...supportedChains.map(chain => chain.id)],
             projectId,

--- a/package/src/compoundComps/ConnectButton/ConnectButton.tsx
+++ b/package/src/compoundComps/ConnectButton/ConnectButton.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useState } from 'react';
 import { Button } from '../../components/ui/Button/Button';
 import { Modal, ModalProps } from '../../components/ui/Modal/Modal';
 import { WalletButton } from '../../components/ui/WalletButton/WalletButton';
-import { useMetaMaskWallet } from '../../components/Wallets/metaMaskWallet';
-import { useWalletConnectWallet } from '../../components/Wallets/walletConnectWallet';
+import { useMetaMaskWallet } from '../../components/Wallets/MetaMask/metaMaskWallet';
+import { useWalletConnectWallet } from '../../components/Wallets/WalletConnect/walletConnectWallet';
 import {
   useDisconnect,
   useWalletConnecting,

--- a/stories/BaseComponents/WalletConnect.stories.tsx
+++ b/stories/BaseComponents/WalletConnect.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { goerli, mainnet } from 'viem/chains';
+import { ConnectButton, KitProvider, SwitchNetworks } from '../../package/src';
+
+const Comp = () => {
+  if (typeof window?.ethereum === 'undefined') return <>Not on the browser</>;
+  return (
+    <KitProvider
+      projectId="5a13f1a5297da2cd768519079890e4fe"
+      initialChain={mainnet}
+      supportedChains={[mainnet, goerli]}
+    >
+      <ConnectButton />
+      <SwitchNetworks />
+    </KitProvider>
+  );
+};
+
+const meta: Meta<typeof Comp> = {
+  title: 'WalletConnect/ConnectButton',
+  component: Comp,
+};
+
+export default meta;
+type Story = StoryObj<typeof Comp>;
+
+export const Primary: Story = {
+  args: {},
+};

--- a/useAccount.md
+++ b/useAccount.md
@@ -1,0 +1,27 @@
+# useAccount
+This hook provides data regarding the connected account. 
+### Usage
+```tsx
+import {useAccount } from '@nazeeh2000/comp-kit'
+
+const Comp = () => {
+  const { address, isConnected } = useAccount();
+  
+  return (
+  // Your component
+  )
+}
+```
+
+### Return Values
+```tsx
+const {
+      address,
+      connecting,
+      error,
+      status, // 'connecting' | 'connected' | 'disconnected' | 'error'
+      isConnected,
+      disconnectWallet,
+      walletProvider, // shows which wallet provider is connected e.g. MetaMask or WalletConnect
+} = useAccount()
+```

--- a/useChain.md
+++ b/useChain.md
@@ -1,0 +1,22 @@
+# useChain
+This hook provides data regarding the current user network and all the supported chains the user has passed to the `KitProvider` wrapper.
+
+### Usage
+```tsx
+import { useChain } from '@nazeeh2000/comp-kit'
+
+const Comp = () => {
+   const { currentChain } = useChain();
+  
+  return (
+  // Your component
+  )
+}
+```
+### Return Values
+```tsx
+const {
+    currentChain,
+    supportedChains // returns an array of Chains of type Chain[]
+} = useChain()
+```


### PR DESCRIPTION
Earlier, `useEffect` for retrieving the chains and addresses was in the `AddressContext` and `ChainContext`. Now I have moved that to a separate file which adds event listeners only if the connected wallet is MetaMask